### PR TITLE
Fix compile issue on later ESPHome (fixes #2)

### DIFF
--- a/hanover_flipdot/hanover_flipdot.h
+++ b/hanover_flipdot/hanover_flipdot.h
@@ -27,6 +27,10 @@ class hanover_flipdot : public PollingComponent, public display::DisplayBuffer, 
   void setup() override {
     this->initialize();
   }
+ 
+  display::DisplayType get_display_type() override {
+   return display::DisplayType::DISPLAY_TYPE_BINARY;
+  }
 
  protected:
   void draw_absolute_pixel_internal(int x, int y, Color color) override;


### PR DESCRIPTION
Implement the "get_display_type()" method, which is required by later ESPHome releases.